### PR TITLE
Do the required init work in designed initializer of NSToolbarItem

### DIFF
--- a/TAAdaptiveSpaceItem/TAAdaptiveSpaceItem.m
+++ b/TAAdaptiveSpaceItem/TAAdaptiveSpaceItem.m
@@ -9,14 +9,24 @@
 #import "TAAdaptiveSpaceItem.h"
 #import "TAAdaptiveSpaceItemView.h"
 
+// Private
+@interface TAAdaptiveSpaceItem ()
+- ( void ) doAdaptiveSpaceItemInit_;
+@end // Private
+
 @implementation TAAdaptiveSpaceItem
 
-- (void)awakeFromNib
+- (instancetype ) initWithItemIdentifier:(NSString *)itemIdentifier
 {
-    TAAdaptiveSpaceItemView *adaptiveSpaceItemView = [[TAAdaptiveSpaceItemView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1)];
-    adaptiveSpaceItemView.adaptiveSpaceItem = self;
-    self.view = adaptiveSpaceItemView;
+    if ( self = [ super initWithItemIdentifier: itemIdentifier ] )
+        [ self doAdaptiveSpaceItemInit_ ];
+    return self;
 }
+
+- (void) awakeFromNib
+    {
+    [ self doAdaptiveSpaceItemInit_ ];
+    }
 
 - (NSString *)label
 {
@@ -68,5 +78,14 @@
     [self setMinSize:[self minSize]];
     [self setMaxSize:[self maxSize]];
 }
+
+// Private
+
+- ( void ) doAdaptiveSpaceItemInit_
+    {
+    TAAdaptiveSpaceItemView *adaptiveSpaceItemView = [[TAAdaptiveSpaceItemView alloc] initWithFrame:NSMakeRect(0, 0, 1, 1)];
+    adaptiveSpaceItemView.adaptiveSpaceItem = self;
+    self.view = adaptiveSpaceItemView;
+    }
 
 @end


### PR DESCRIPTION
First of all, thank you for your awesome work✨.

Well, instead of **loading a compiled xib file**, in my own project I created instance of `TAAdaptiveSpaceItem` with the inherited designed initializer of `NSToolbarItem`: `initWithItemIdentifier:`. However, all the required init work was only listed in [`awakeFromNib`](https://github.com/timothyarmes/TAAdaptiveSpaceItem/blob/master/TAAdaptiveSpaceItem/TAAdaptiveSpaceItem.m#L14) then in my scenario the init code would never get called.

For details, check out the [Files Changed](https://github.com/timothyarmes/TAAdaptiveSpaceItem/pull/2/files) section.
